### PR TITLE
Change fct_reviews materialization to incremental

### DIFF
--- a/models/marts/airbnb/core/fct_reviews.sql
+++ b/models/marts/airbnb/core/fct_reviews.sql
@@ -1,3 +1,19 @@
-{{ config(materialized='table') }}
+{{
+    config(
+        materialized='incremental',
+        unique_key='review_id',
+    )
+}}
 
-select * from {{ ref('stg_airbnb_reviews') }}
+select
+    review_id,
+    listing_id,
+    reviewer_id,
+    reviewer_name,
+    comments,
+    reviewed_at
+from {{ ref('stg_airbnb_reviews') }}
+
+{% if is_incremental() %}
+where reviewed_at >= (select max(reviewed_at) from {{ this }})
+{% endif %}


### PR DESCRIPTION
Why: Our Databricks project is missing an incremental model. The `stg_airbnb_reviews` is a natural source to build an incremental off of because it has a `reviewed_at` column.