### PR TITLE
adds lots of descriptions + enables persist docs

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -35,7 +35,9 @@ dispatch:
 # as tables. These settings can be overridden in the individual model files
 # using the `{{ config(...) }}` macro.
 models:
-
+  +persist_docs:
+    relation: true
+    columns: true
   databricks_demo:
       staging:
           materialized: table

--- a/models/marts/core/core.yml
+++ b/models/marts/core/core.yml
@@ -9,31 +9,159 @@ models:
         tests:
           - unique
           - not_null
-                
+      - name: region
+        description: region name
+        tests:
+          - accepted_values:
+              values: ['AFRICA','MIDDLE EAST','ASIA','EUROPE','AMERICA']
+              severity: warn
+      - name: name
+        description: customer id
+      - name: address
+        description: address of the customer
+      - name: nation
+        description: nation name
+      - name: phone_number
+        description: phone number of the customer
+      - name: account_balance
+        description: '{{ doc("account_balance") }}'
+      - name: market_segment
+        description: market segment of the customer
+
+
   - name: dim_parts
+    description: Parts dimensions table
     columns:
       - name: part_key
+        description: primary key of the model
         tests:
           - unique
           - not_null
+      - name: manufacturer
+        description: manufacturer of the part
+      - name: name
+        description: name of the part
+      - name: brand
+        description: brand of the part
+      - name: type
+        description: type of part including material
+      - name: size
+        description: size of the part
+      - name: container
+        description: container of the part
+      - name: retail_price
+        description: '{{ doc("retail_price") }}'
 
   - name: dim_suppliers
+    description: Suppliers dimensions table
     columns:
       - name: supplier_key
+        description: primary key of the model
         tests:
           - unique
           - not_null
-
+      - name: supplier_name
+        description: '{{ doc("supplier_name") }}'
+      - name: supplier_address
+        description: '{{ doc("supplier_address") }}'
+      - name: nation
+        description: nation name
+      - name: region
+        description: region name
+      - name: phone_number
+        description: '{{ doc("phone_number") }}'
+      - name: account_balance
+        description: '{{ doc("account_balance") }}'
+ 
   - name: fct_order_items
+    description: order items fact table
     columns:
       - name: order_item_key
+        description: '{{ doc("order_item_key") }}'
         tests:
           - unique
           - not_null
-                
+      - name: order_key
+        description: foreign key for orders
+      - name: order_date
+        description: date of the order
+      - name: customer_key
+        description: foreign key for customers
+      - name: part_key
+        description: foreign key for part
+      - name: supplier_key
+        description: foreign key for suppliers
+      - name: order_item_status_code
+        description: status of the order item
+      - name: return_flag
+        description: '{{ doc("return_flag") }}'
+      - name: line_number
+        description: '{{ doc("line_number") }}'
+      - name: ship_date
+        description: '{{ doc("ship_date") }}'
+      - name: commit_date
+        description: '{{ doc("commit_date") }}'
+      - name: receipt_date
+        description: '{{ doc("receipt_date") }}'
+      - name: ship_mode
+        description: '{{ doc("ship_mode") }}'
+      - name: supplier_cost
+        description: '{{ doc("cost") }}'
+      - name: base_price
+        description: '{{ doc("base_price") }}'
+      - name: discount_percentage
+        description: '{{ doc("discount_percentage") }}'
+      - name: discounted_price
+        description: '{{ doc("discounted_price") }}'
+      - name: tax_rate
+        description: '{{ doc("tax_rate") }}'
+      - name: order_item_count
+        description: count of order items
+      - name: quantity
+        description: total units
+      - name: gross_item_sales_amount
+        description: '{{ doc("gross_item_sales_amount") }}'
+      - name: discounted_item_sales_amount
+        description: '{{ doc("discounted_item_sales_amount") }}'
+      - name: item_discount_amount
+        description: '{{ doc("item_discount_amount") }}'
+      - name: item_tax_amount
+        description: '{{ doc("item_tax_amount") }}'
+      - name: net_item_sales_amount
+        description: '{{ doc("net_item_sales_amount") }}'
+  
   - name: fct_orders
+    description: orders fact table
     columns:
       - name: order_key
+        description: primary key of the model
         tests:
           - unique
           - not_null
+      - name: customer_key
+        description: foreign key for customers
+        tests:
+          - relationships:
+              to: ref('dim_customers')
+              field: customer_key
+              severity: error
+      - name: order_date
+        description: date of the order
+      - name: status_code
+        description: status of the order
+      - name: priority_code
+        description: code associated with the order
+      - name: clerk_name
+        description: id of the clerk
+      - name: ship_priority
+        description: numeric representation of the shipping priority, zero being the default
+      - name: order_count
+        description: number of orders (includes returns)
+      - name: gross_item_sales_amount
+        description: '{{ doc("gross_item_sales_amount") }}'
+      - name: item_discount_amount
+        description: '{{ doc("item_discount_amount") }}'
+      - name: item_tax_amount
+        description: '{{ doc("item_tax_amount") }}'
+      - name: net_item_sales_amount
+        description: '{{ doc("net_item_sales_amount") }}'

--- a/models/staging/staging.md
+++ b/models/staging/staging.md
@@ -1,0 +1,61 @@
+# the intent of this .md is to remove redundancy in the documentation
+
+
+# the below are descriptions from stg_tpch_line_items
+
+{% docs order_item_key %} surrogate key for the model -- combo of order_key + line_number {% enddocs %}
+
+{% docs line_number %} sequence of the order items within the order {% enddocs %}
+
+{% docs return_flag %} letter determining the status of the return (r is returned) {% enddocs %}
+
+{% docs ship_date %} the date the order item is being shipped {% enddocs %}
+
+{% docs commit_date %} the date the order item is being commited {% enddocs %}
+
+{% docs receipt_date %} the receipt date of the order item {% enddocs %}
+
+{% docs ship_mode %} method of shipping {% enddocs %}
+
+{% docs comment %} additional commentary {% enddocs %}
+
+{% docs extended_price %} line item price {% enddocs %}
+
+{% docs discount_percentage %} percentage of the discount {% enddocs %}
+
+
+# the below are descriptions from stg_tpch_supppliers
+
+{% docs supplier_name %} id of the supplier {% enddocs %}
+
+{% docs supplier_address %} address of the supplier {% enddocs %}
+
+{% docs phone_number %} phone number of the supplier {% enddocs %}
+
+{% docs account_balance %} raw account balance {% enddocs %}
+
+# the below are descriptions from stg_tpch_parts
+
+{% docs retail_price %} raw retail price {% enddocs %}
+
+# the below are descriptions from stg_tpch_part_suppliers
+
+{% docs available_quantity %} raw available quantity {% enddocs %}
+
+{% docs cost %} raw cost {% enddocs %}
+
+{% docs base_price %} since extended_price is the line item total, we back out the price per item {% enddocs %}
+
+{% docs discounted_price %} factoring in the discount_percentage, the line item discount total {% enddocs %}
+
+{% docs tax_rate %} tax rate of the order item {% enddocs %}
+
+{% docs gross_item_sales_amount %} same as extended_price {% enddocs %}
+
+{% docs discounted_item_sales_amount %} line item (includes quantity) discount amount{% enddocs %}
+
+{% docs item_discount_amount %} item level discount amount. this is always a negative number {% enddocs %}
+
+{% docs item_tax_amount %} item level tax total {% enddocs %}
+
+{% docs net_item_sales_amount %} the net total which factors in discount and tax {% enddocs %}


### PR DESCRIPTION
Wanted to show what Unity Catalog is like, so enabled persist docs + added descriptions to things

![image](https://user-images.githubusercontent.com/47784/207846280-552dc7f4-94b0-4a34-943b-992bc066102f.png)
