### PR TITLE
Fixing Databricks demo on master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 
 target/
 dbt_packages/
+dbt_modules/
 logs/

--- a/models/staging/tpch/tpch_sources.yml
+++ b/models/staging/tpch/tpch_sources.yml
@@ -3,7 +3,6 @@ version: 2
 sources:
   - name: tpch
     schema: tpch
-    catalog: hive_metastore
     
     tables:
       - name: orders


### PR DESCRIPTION
Just a couple small updates here -- .gitignore needed dbt_modules added, and there was a change required on the tpch sources to make sure it uses data in unity catalog data by default